### PR TITLE
Bug fix

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,7 +55,7 @@ function randomSelect(){
 }
 
 function pickRandomTag(){
-    const tags = document.querySelectorAll('tag')
+    const tags = document.querySelectorAll('.tag')
     return tags[Math.floor(Math.random() * tags.length)]
 }
 


### PR DESCRIPTION
when selecting using either ```document.querySelector``` or ```document.querySelectorAll```, you can just write the name of the class or the id. If its a class, you'll have to prepend it with a period (.) and if it's an id, you'll have to prepend it with a hash (#).